### PR TITLE
New jupiter notebook for ligand parametrisation for CNS/HADDOCK

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,14 @@
 
 ***
 
-This tutorial aims to illustrate the process of **ligand parameterization** for a **small molecule**, step by step, using the **BioExcel Building Blocks library (biobb)**. The particular example used is the **Sulfasalazine** protein (3-letter code SAS), used to treat rheumatoid arthritis, ulcerative colitis, and Crohn's disease.
+This tutorial aims to illustrate the process of **ligand parameterization** for a **small molecule**, step by step, using the **BioExcel Building Blocks library (biobb)**. 
 
-**OpenBabel and ACPype** packages are used to **add hydrogens, energetically minimize the structure**, and **generate parameters** for the **GROMACS** package. With *Generalized Amber Force Field (GAFF) forcefield and AM1-BCC* charges.
+Two examples are provided:
+
+1. One uses is the **Sulfasalazine** protein (3-letter code SAS), used to treat rheumatoid arthritis, ulcerative colitis, and Crohn's disease, generating parameters for the the **GROMACS** package.
+2. The second example used Oseltamivir (also called Tamiflu), an antiviral drug, generating parameters for use in CNS (the computational engine used for example by **HADDOCK*). 
+
+**OpenBabel and ACPype** packages are used to **add hydrogens, energetically minimize the structure**, and **generate parameters** with *Generalized Amber Force Field (GAFF) forcefield and AM1-BCC* charges.
 
 ***
 
@@ -30,7 +35,16 @@ git clone https://github.com/bioexcel/biobb_wf_ligand_parameterization.git
 cd biobb_wf_ligand_parameterization
 conda env create -f conda_env/environment.yml
 conda activate biobb_ligand_parameterization_tutorial
+```
+
+For parametrizing a ligand for use in **GROMACS** launch the following notebook:
+```console
 jupyter-notebook biobb_wf_ligand_parameterization/notebooks/biobb_ligand_parameterization_tutorial.ipynb
+```
+
+For parametrizing a ligand for use in **CNS/HADDOCK** launch the following notebook:
+```console
+jupyter-notebook biobb_wf_ligand_parameterization/notebooks/biobb_ligand_CNS_parameterization_tutorial.ipynb
 ```
 
 ***
@@ -39,12 +53,14 @@ jupyter-notebook biobb_wf_ligand_parameterization/notebooks/biobb_ligand_paramet
 
 Click here to [view tutorial in Read the Docs](https://biobb-wf-ligand-parameterization.readthedocs.io/en/latest/index.html)
 
-Click here to [execute tutorial in Binder](https://mybinder.org/v2/gh/bioexcel/biobb_wf_ligand_parameterization/HEAD?labpath=biobb_wf_ligand_parameterization%2Fnotebooks%2Fbiobb_ligand_parameterization_tutorial.ipynb)
+Click here to [execute the GROMACS parametrization tutorial in Binder](https://mybinder.org/v2/gh/bioexcel/biobb_wf_ligand_parameterization/HEAD?labpath=biobb_wf_ligand_parameterization%2Fnotebooks%2Fbiobb_ligand_parameterization_tutorial.ipynb)
+
+Click here to [execute the CNS parametrization tutorial in Binder](https://mybinder.org/v2/gh/bioexcel/biobb_wf_ligand_parameterization/HEAD?labpath=biobb_wf_ligand_parameterization%2Fnotebooks%2Fbiobb_ligand_CNS_parameterization_tutorial.ipynb)
 
 ***
 
 ## Version
-2023.3
+2023.12
 
 ## Copyright & Licensing
 This software has been developed in the [MMB group](http://mmb.irbbarcelona.org) at the [BSC](http://www.bsc.es/) & [IRB](https://www.irbbarcelona.org/) for the [European BioExcel](http://bioexcel.eu/), funded by the European Commission (EU H2020 [823830](http://cordis.europa.eu/projects/823830), EU H2020 [675728](http://cordis.europa.eu/projects/675728)).

--- a/biobb_wf_ligand_parameterization/notebooks/biobb_ligand_CNS_parameterization_tutorial.ipynb
+++ b/biobb_wf_ligand_parameterization/notebooks/biobb_ligand_CNS_parameterization_tutorial.ipynb
@@ -1,0 +1,440 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Automatic Ligand parameterization tutorial using BioExcel Building Blocks (biobb)\n",
+    "***\n",
+    "This tutorial aims to illustrate the process of **ligand parameterization** for a **small molecule**, step by step, using the **BioExcel Building Blocks library (biobb)**. The particular example used is the **Ozeltamivir** an antiviral drug (3-letter code G39, Drugbank code [DB00198](https://www.drugbank.ca/drugs/DB00198). \n",
+    "\n",
+    "**OpenBabel and ACPype** packages are used to **add hydrogens**, **energetically minimize the structure**, and \n",
+    "**generate parameters** for the **CNS** package. With *Generalized Amber Force Field (GAFF)* forcefield and *AM1-BCC* charges.  \n",
+    "***\n",
+    "**Biobb modules** used:\n",
+    "\n",
+    " - [biobb_io](https://github.com/bioexcel/biobb_io): Tools to fetch data to be consumed by the rest of the Biobb building blocks.\n",
+    " - [biobb_chemistry](https://github.com/bioexcel/biobb_chemistry): Tools to manipulate chemistry data.\n",
+    " \n",
+    "### Auxiliar libraries used\n",
+    "\n",
+    "* [jupyter](https://jupyter.org/): Free software, open standards, and web services for interactive computing across all programming languages.\n",
+    "* [nglview](http://nglviewer.org/#nglview): Jupyter/IPython widget to interactively view molecular structures and trajectories in notebooks.\n",
+    "\n",
+    "### Conda Installation and Launch\n",
+    "\n",
+    "```console\n",
+    "git clone https://github.com/bioexcel/biobb_wf_ligand_parameterization.git\n",
+    "cd biobb_wf_ligand_parameterization\n",
+    "conda env create -f conda_env/environment.yml\n",
+    "conda activate biobb_ligand_parameterization_tutorial\n",
+    "jupyter-notebook biobb_wf_ligand_parameterization/notebooks/biobb_ligand_parameterization_tutorial.ipynb\n",
+    "```\n",
+    "\n",
+    "***\n",
+    "### Pipeline steps:\n",
+    " 1. [Input Parameters](#input)\n",
+    " 2. [Fetching Ligand Structure](#fetch)\n",
+    " 3. [Add Hydrogen Atoms](#addh)\n",
+    " 4. [Energetically Minimize Hydrogen Atoms](#min)\n",
+    " 5. [Generating Ligand Parameters](#acpype)\n",
+    " 6. [Output Files](#output)\n",
+    " 7. [Questions & Comments](#questions)\n",
+    " \n",
+    "***\n",
+    "![](https://bioexcel.eu/wp-content/uploads/2019/04/Bioexcell_logo_1080px_transp.png)\n",
+    "***"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id=\"input\"></a>\n",
+    "***\n",
+    "## Input parameters\n",
+    "**Input parameters** needed:\n",
+    " - **ligandCode**: 3-letter code of the ligand structure (e.g. G39)\n",
+    " - **mol_charge**: Molecule net charge (e.g. -1)\n",
+    " - **pH**: Acidity or alkalinity for the small molecule. Hydrogen atoms will be added according to this pH. (e.g. 7.4)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import nglview\n",
+    "import ipywidgets\n",
+    "import os\n",
+    "\n",
+    "ligandCode = 'G39'\n",
+    "mol_charge = 0\n",
+    "pH = 7.4"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id=\"fetch\"></a>\n",
+    "***\n",
+    "## Fetching ligand structure\n",
+    "Downloading **ligand structure** in **PDB format** from the IRB PDB MIRROR database.<br>\n",
+    "Alternatively, a **PDB file** can be used as starting structure. <br>\n",
+    "***\n",
+    "**Building Blocks** used:\n",
+    "\n",
+    " - [Ligand](https://biobb-io.readthedocs.io/en/latest/api.html#module-api.ligand) from **biobb_io.api.ligand**\n",
+    "***"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Ligand: Download ligand structure from MMB PDB mirror REST API (https://mmb.irbbarcelona.org/api/)\n",
+    "# Import module\n",
+    "from biobb_io.api.ligand import ligand\n",
+    "\n",
+    "# Create prop dict and inputs/outputs\n",
+    "input_structure = ligandCode + '.pdb'\n",
+    "\n",
+    "prop = {\n",
+    "    'ligand_code' : ligandCode\n",
+    "}\n",
+    "\n",
+    "#Create and launch bb\n",
+    "ligand(output_pdb_path=input_structure,\n",
+    "        properties=prop)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Visualizing 3D structure\n",
+    "Visualizing the downloaded/given **ligand PDB structure** using **NGL**:    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "#Show small ligand structure\n",
+    "view = nglview.show_structure_file(input_structure)\n",
+    "view.add_representation(repr_type='ball+stick', selection='all')\n",
+    "view._remote_call('setSize', target='Widget', args=['','300px'])\n",
+    "view.camera='orthographic'\n",
+    "view"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id=\"addh\"></a>\n",
+    "***\n",
+    "## Add Hydrogen Atoms\n",
+    "Adding **Hydrogen atoms** to the small molecule, according to the given pH.\n",
+    "***\n",
+    "**Building Blocks** used:\n",
+    " - [BabelAddHydrogens](https://biobb-chemistry.readthedocs.io/en/latest/babelm.html#module-babelm.babel_add_hydrogens) from **biobb_chemistry.babelm.babel_add_hydrogens** \n",
+    "***"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Babel_add_hydrogens: add Hydrogen atoms to a small molecule\n",
+    "# Import module\n",
+    "from biobb_chemistry.babelm.babel_add_hydrogens import babel_add_hydrogens\n",
+    "\n",
+    "# Create prop dict and inputs/outputs\n",
+    "output_babel_h = ligandCode + '.H.mol2' \n",
+    "\n",
+    "prop = {\n",
+    "    'ph' : pH,\n",
+    "    'input_format' : 'pdb',\n",
+    "    'output_format' : 'mol2'\n",
+    "}\n",
+    "\n",
+    "#Create and launch bb\n",
+    "babel_add_hydrogens(input_path=input_structure,\n",
+    "                  output_path=output_babel_h,\n",
+    "                  properties=prop)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Visualizing 3D structure\n",
+    "Visualizing the **ligand PDB structure** with the newly added **hydrogen atoms** using **NGL**:    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "#Show small ligand structure\n",
+    "view = nglview.show_structure_file(output_babel_h)\n",
+    "view.add_representation(repr_type='ball+stick', selection='all')\n",
+    "view.camera='orthographic'\n",
+    "view"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id=\"min\"></a>\n",
+    "***\n",
+    "## Energetically minimize Hydrogen Atoms\n",
+    "Energetically minimize newly added **Hydrogen atoms**.\n",
+    "***\n",
+    "**Building Blocks** used:\n",
+    " - [BabelMinimize](https://biobb-chemistry.readthedocs.io/en/latest/babelm.html#module-babelm.babel_minimize) from **biobb_chemistry.babelm.babel_minimize** \n",
+    "***"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Babel_minimize: Structure energy minimization of a small molecule after being modified adding hydrogen atoms\n",
+    "# Import module\n",
+    "from biobb_chemistry.babelm.babel_minimize import babel_minimize\n",
+    "\n",
+    "# Create prop dict and inputs/outputs\n",
+    "output_babel_min = ligandCode + '.H.min.pdb'                              \n",
+    "prop = {\n",
+    "    'method' : 'sd',\n",
+    "    'criteria' : '1e-10',\n",
+    "    'force_field' : 'GAFF'\n",
+    "}\n",
+    "\n",
+    "\n",
+    "#Create and launch bb\n",
+    "babel_minimize(input_path=output_babel_h,\n",
+    "              output_path=output_babel_min,\n",
+    "              properties=prop)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Visualizing 3D structure\n",
+    "Visualizing the **ligand PDB structure** with the newly added **hydrogen atoms**, **energetically minimized**, using **NGL**:    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "#Show small ligand structure\n",
+    "view = nglview.show_structure_file(output_babel_min)\n",
+    "view.add_representation(repr_type='ball+stick', selection='all')\n",
+    "view._remote_call('setSize', target='Widget', args=['','300px'])\n",
+    "view.camera='orthographic'\n",
+    "view"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Visualizing 3D structures\n",
+    "Visualizing all the structures generated so far:\n",
+    "\n",
+    " - Original **ligand PDB structure** (left)\n",
+    " - **Ligand PDB structure** with **hydrogen atoms** (middle)\n",
+    " - **Ligand PDB structure** with **hydrogen atoms energetically minimized** (right)  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "#Show different structures generated (for comparison)\n",
+    "view1 = nglview.show_structure_file(input_structure)\n",
+    "view1.add_representation(repr_type='ball+stick')\n",
+    "view1._remote_call('setSize', target='Widget', args=['250px','300px'])\n",
+    "view1.camera='orthographic'\n",
+    "view1\n",
+    "view2 = nglview.show_structure_file(output_babel_h)\n",
+    "view2.add_representation(repr_type='ball+stick')\n",
+    "view2._remote_call('setSize', target='Widget', args=['250px','300px'])\n",
+    "view2.camera='orthographic'\n",
+    "view2\n",
+    "view3 = nglview.show_structure_file(output_babel_min)\n",
+    "view3.add_representation(repr_type='ball+stick')\n",
+    "view3._remote_call('setSize', target='Widget', args=['250px','300px'])\n",
+    "view3.camera='orthographic'\n",
+    "view3\n",
+    "ipywidgets.HBox([view1, view2, view3])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id=\"acpype\"></a>\n",
+    "***\n",
+    "## Generating ligand parameters\n",
+    "**Building CNS topology** corresponding to the **ligand structure**.\n",
+    "\n",
+    "**Force field** used in this tutorial step is **amberGAFF**: [General AMBER Force Field](http://ambermd.org/antechamber/gaff.html), designed for rational drug design.\n",
+    "\n",
+    "***\n",
+    "**Building Blocks** used:\n",
+    "- [AcpypeParamsCNS](https://biobb-chemistry.readthedocs.io/en/latest/acpype.html#module-acpype.acpype_params_cns) from **biobb_chemistry.acpype.acpype_params_cns** \n",
+    "***"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Acpype_params_cns: Generation of topologies for CNS with ACPype\n",
+    "# Import module\n",
+    "import shutil\n",
+    "from biobb_chemistry.acpype.acpype_params_cns import acpype_params_cns\n",
+    "\n",
+    "# Create prop dict and inputs/outputs\n",
+    "output_acpype_inp = ligandCode + 'params.inp'\n",
+    "output_acpype_par = ligandCode + 'params.par'\n",
+    "output_acpype_top = ligandCode + 'params.top'\n",
+    "output_acpype_pdb = ligandCode + 'params.pdb'\n",
+    "output_acpype = ligandCode + 'params'\n",
+    "prop = {\n",
+    "    'basename' : output_acpype,\n",
+    "    'charge' : mol_charge\n",
+    "}\n",
+    "\n",
+    "#Create and launch bb\n",
+    "acpype_params_cns(input_path=output_babel_min,\n",
+    "                output_path_inp=output_acpype_inp,\n",
+    "                output_path_par=output_acpype_par,\n",
+    "                output_path_top=output_acpype_top,\n",
+    "                properties=prop)\n",
+    "\n",
+    "shutil.copyfile(output_babel_min, output_acpype_pdb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Visualizing 3D structure\n",
+    "Visualizing the generated PDB structure corresponding to the parameterized **ligand PDB structure** using **NGL**:    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Show small ligand structure\n",
+    "view = nglview.show_structure_file(output_acpype_pdb)\n",
+    "view.add_representation(repr_type='ball+stick', selection='all')\n",
+    "view._remote_call('setSize', target='Widget', args=['','300px'])\n",
+    "view.camera='orthographic'\n",
+    "view"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "jp-MarkdownHeadingCollapsed": true,
+    "variables": {
+     "output_acpype_par": "G39params.par",
+     "output_acpype_pdb": "G39params.pdb",
+     "output_acpype_top": "G39params.top"
+    }
+   },
+   "source": [
+    "<a id=\"output\"></a>\n",
+    "## Output files\n",
+    "\n",
+    "Important **Output files** generated:\n",
+    " - {{output_acpype_pdb}}: **Structure** of the parameterized ligand in PDB format.\n",
+    " - {{output_acpype_top}}: **Topology File** of the parameterized ligand, including a reference to the {{output_acpype_top}}.\n",
+    " - {{output_acpype_par}}: **Parameter File** of the parameterized ligand, including the parameters information: bonds, angles, dihedrals, etc."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "***\n",
+    "<a id=\"questions\"></a>\n",
+    "\n",
+    "## Questions & Comments\n",
+    "\n",
+    "Questions, issues, suggestions and comments are really welcome!\n",
+    "\n",
+    "* GitHub issues:\n",
+    "    * [https://github.com/bioexcel/biobb](https://github.com/bioexcel/biobb)\n",
+    "\n",
+    "* BioExcel forum:\n",
+    "    * [https://ask.bioexcel.eu/c/BioExcel-Building-Blocks-library](https://ask.bioexcel.eu/c/BioExcel-Building-Blocks-library)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.0"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "31f2aee4e71d21fbe5cf8b01ff0e069b9275f58929596ceb00d14d90e3e16cd6"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
This notebook will create the topo/param files for use in CNS, the computational engine used by HADDOCK.
The generated topo/param files have been tested in HADDOCK and work fine (meaning a docking run complete without problems when using those).
