### PR TITLE
Added a step to ensure unique atom names using pdb-tools

### DIFF
--- a/biobb_wf_ligand_parameterization/notebooks/biobb_ligand_CNS_parameterization_tutorial.ipynb
+++ b/biobb_wf_ligand_parameterization/notebooks/biobb_ligand_CNS_parameterization_tutorial.ipynb
@@ -161,18 +161,41 @@
     "from biobb_chemistry.babelm.babel_add_hydrogens import babel_add_hydrogens\n",
     "\n",
     "# Create prop dict and inputs/outputs\n",
-    "output_babel_h = ligandCode + '.H.mol2' \n",
+    "output_babel_h = ligandCode + '.H.pdb' \n",
     "\n",
     "prop = {\n",
     "    'ph' : pH,\n",
     "    'input_format' : 'pdb',\n",
-    "    'output_format' : 'mol2'\n",
+    "    'output_format' : 'pdb'\n",
     "}\n",
     "\n",
     "#Create and launch bb\n",
     "babel_add_hydrogens(input_path=input_structure,\n",
     "                  output_path=output_babel_h,\n",
     "                  properties=prop)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Ensure unique atom names\n",
+    "As obabel generates overlapping atom names, correct this ensuring unique atom names using  **pdb_uniqname** from **PDB-TOOLS**:    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# make sure atom names are unique\n",
+    "import subprocess\n",
+    "\n",
+    "output_babel_hu = ligandCode + '.H.uniq.pdb' \n",
+    "command = 'pdb_uniqname ' + output_babel_h + '> ' + output_babel_hu\n",
+    "\n",
+    "subprocess.call(command, shell=True)"
    ]
   },
   {
@@ -192,7 +215,7 @@
    "outputs": [],
    "source": [
     "#Show small ligand structure\n",
-    "view = nglview.show_structure_file(output_babel_h)\n",
+    "view = nglview.show_structure_file(output_babel_hu)\n",
     "view.add_representation(repr_type='ball+stick', selection='all')\n",
     "view.camera='orthographic'\n",
     "view"
@@ -232,7 +255,7 @@
     "\n",
     "\n",
     "#Create and launch bb\n",
-    "babel_minimize(input_path=output_babel_h,\n",
+    "babel_minimize(input_path=output_babel_hu,\n",
     "              output_path=output_babel_min,\n",
     "              properties=prop)"
    ]
@@ -287,7 +310,7 @@
     "view1._remote_call('setSize', target='Widget', args=['250px','300px'])\n",
     "view1.camera='orthographic'\n",
     "view1\n",
-    "view2 = nglview.show_structure_file(output_babel_h)\n",
+    "view2 = nglview.show_structure_file(output_babel_hu)\n",
     "view2.add_representation(repr_type='ball+stick')\n",
     "view2._remote_call('setSize', target='Widget', args=['250px','300px'])\n",
     "view2.camera='orthographic'\n",
@@ -344,6 +367,7 @@
     "                output_path_inp=output_acpype_inp,\n",
     "                output_path_par=output_acpype_par,\n",
     "                output_path_top=output_acpype_top,\n",
+    "                output_path_pdb=output_acpype_pdb,\n",
     "                properties=prop)\n",
     "\n",
     "shutil.copyfile(output_babel_min, output_acpype_pdb)"

--- a/conda_env/environment.yml
+++ b/conda_env/environment.yml
@@ -7,3 +7,4 @@ dependencies:
   - biobb_chemistry==4.1.0
   - jupyter
   - nglview
+  - pdb-tools


### PR DESCRIPTION
As obabel generates overlapping atom names (e.g. all carbons are call simply C) this is giving problems downstream when using the generated PDB file.

To solve this problem I added a step using `pdb_uniqname` from pdb-tools to ensure unique atom names.